### PR TITLE
Fixes to compile with dear imgui 1.80 + warning fixes.

### DIFF
--- a/ImFileDialog.h
+++ b/ImFileDialog.h
@@ -5,6 +5,7 @@
 #include <thread>
 #include <functional>
 #include <unordered_map>
+#include <algorithm> // std::min, std::max
 
 #define IFD_DIALOG_FILE			0
 #define IFD_DIALOG_DIRECTORY	1


### PR DESCRIPTION
Minor fixes (your code previously used alpha table api some of which had changed)

Also note that for right/bottom align -FLT_MIN is more correct than -1.0f which will remove an extra pixel) hence those changes.

Note that I didn't yet run `ImFileDialog`, this is merely putting some fixes out ahead for users who will try to use it with dear imgui `master`. I'm also getting two std::string related warning I haven't inspected yet.