### PR TITLE
Lowercase Win32 include names for MinGW compatibility on case-sensitive systems

### DIFF
--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -14,9 +14,9 @@
 #include "stb_image.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <shellapi.h>
-#include <Lmcons.h>
+#include <lmcons.h>
 #pragma comment(lib, "Shell32.lib")
 #else
 #include <unistd.h>


### PR DESCRIPTION
MinGW toolchain uses lowercase names for all provided header files, unlike what can be found in some of Microsoft's documentation. On Windows it does not actually matter since it's (almost) always case-insensitive. However, when cross-compiling from Linux (or another operating/file systems which are usually case-sensitive) with MinGW, the compiler is not able to find the headers with capital letters, so lowercase names must be used instead.