### PR TITLE
Improve cancel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,9 @@ set(SOURCES
 	libs/imgui/imgui.cpp
 	libs/imgui/imgui_widgets.cpp
 	libs/imgui/imgui_draw.cpp
-	libs/imgui/examples/imgui_impl_opengl3.cpp
-	libs/imgui/examples/imgui_impl_sdl.cpp
+	libs/imgui/imgui_tables.cpp
+	libs/imgui/backends/imgui_impl_opengl3.cpp
+	libs/imgui/backends/imgui_impl_sdl.cpp
 )
 
 # cmake toolchain
@@ -50,7 +51,7 @@ set_target_properties(ImFileDialogExample PROPERTIES
 
 # include directories
 target_include_directories(ImFileDialogExample PRIVATE ${SDL2_INCLUDE_DIRS} ${GLEW_INCLUDE_DIRS} ${OPENGL_INCLUDE_DIRS})
-target_include_directories(ImFileDialogExample PRIVATE libs/)
+target_include_directories(ImFileDialogExample PRIVATE libs libs/imgui)
 
 # link libraries
 target_link_libraries(ImFileDialogExample ${OPENGL_LIBRARIES})

--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -1399,8 +1399,12 @@ namespace ifd {
 #endif
 		}
 		ImGui::SameLine();
-		if (ImGui::Button("Cancel", ImVec2(-FLT_MIN, 0.0f)))
-			m_finalize();
+		if (ImGui::Button("Cancel", ImVec2(-FLT_MIN, 0.0f))) {
+			if (m_type == IFD_DIALOG_DIRECTORY)
+				m_isOpen = false;
+			else
+				m_finalize();
+		}
 	}
 }
 

--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -24,7 +24,7 @@
 #endif
 
 #define ICON_SIZE ImGui::GetFont()->FontSize + 3
-#define GUI_ELEMENT_SIZE 24
+#define GUI_ELEMENT_SIZE std::max(GImGui->FontSize + 10.f, 24.f)
 #define DEFAULT_ICON_SIZE 32
 #define PI 3.141592f
 
@@ -1330,7 +1330,7 @@ namespace ifd {
 
 
 		/***** CONTENT *****/
-		float bottomBarHeight = (GImGui->FontSize + ImGui::GetStyle().FramePadding.y * 2.0f + ImGui::GetStyle().ItemSpacing.y * 2.0f) * 2;
+		float bottomBarHeight = (GImGui->FontSize + ImGui::GetStyle().FramePadding.y + ImGui::GetStyle().ItemSpacing.y * 2.0f) * 2;
 		if (ImGui::BeginTable("##table", 2, ImGuiTableFlags_Resizable, ImVec2(0, -bottomBarHeight))) {
 			ImGui::TableSetupColumn("##tree", ImGuiTableColumnFlags_WidthFixed, 125.0f);
 			ImGui::TableSetupColumn("##content", ImGuiTableColumnFlags_WidthStretch);
@@ -1384,8 +1384,9 @@ namespace ifd {
 		}
 
 		// buttons
-		ImGui::SetCursorPosX(ImGui::GetWindowWidth() - 250);
-		if (ImGui::Button(m_type == IFD_DIALOG_SAVE ? "Save" : "Open", ImVec2(250 / 2 - ImGui::GetStyle().ItemSpacing.x, 0.0f))) {
+		float ok_cancel_width = GUI_ELEMENT_SIZE * 7;
+		ImGui::SetCursorPosX(ImGui::GetWindowWidth() - ok_cancel_width);
+		if (ImGui::Button(m_type == IFD_DIALOG_SAVE ? "Save" : "Open", ImVec2(ok_cancel_width / 2 - ImGui::GetStyle().ItemSpacing.x, 0.0f))) {
 			std::string filename(m_inputTextbox);
 			bool success = false;
 			if (!filename.empty() || m_type == IFD_DIALOG_DIRECTORY)

--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -29,6 +29,9 @@
 #define PI 3.141592f
 
 namespace ifd {
+	static const char* GetDefaultFolderIcon();
+	static const char* GetDefaultFileIcon();
+
 	/* UI CONTROLS */
 	bool FolderNode(const char* label, ImTextureID icon, bool& clicked)
 	{

--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -1405,6 +1405,11 @@ namespace ifd {
 			else
 				m_finalize();
 		}
+
+		int escapeKey = ImGui::GetIO().KeyMap[ImGuiKey_Escape];
+		if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+			 escapeKey >= 0 && ImGui::IsKeyPressed(escapeKey))
+			m_isOpen = false;
 	}
 }
 

--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -78,7 +78,7 @@ namespace ifd {
 		ImGuiContext& g = *GImGui;
 		ImGuiWindow* window = g.CurrentWindow;
 
-		ImU32 id = window->GetID(label);
+		//ImU32 id = window->GetID(label);
 		ImVec2 pos = window->DC.CursorPos;
 		bool ret = ImGui::InvisibleButton(label, ImVec2(-FLT_MIN, g.FontSize + g.Style.FramePadding.y * 2));
 
@@ -139,14 +139,14 @@ namespace ifd {
 			ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, ImGui::GetStyle().ItemSpacing.y));
 			ImGui::PushStyleVar(ImGuiStyleVar_FrameBorderSize, 0.0f);
 			bool isFirstElement = true;
-			for (int i = 0; i < btnList.size(); i++) {
+			for (size_t i = 0; i < btnList.size(); i++) {
 				if (totalWidth > size.x - 30 && i != btnList.size() - 1) { // trim some buttons if there's not enough space
 					float elSize = ImGui::CalcTextSize(btnList[i].c_str()).x + style.FramePadding.x * 2.0f + GUI_ELEMENT_SIZE;
 					totalWidth -= elSize;
 					continue;
 				}
 
-				ImGui::PushID(i);
+				ImGui::PushID(static_cast<int>(i));
 				if (!isFirstElement) {
 					ImGui::ArrowButtonEx("##dir_dropdown", ImGuiDir_Right, ImVec2(GUI_ELEMENT_SIZE, GUI_ELEMENT_SIZE));
 					anyOtherHC |= ImGui::IsItemHovered() | ImGui::IsItemClicked();
@@ -158,7 +158,7 @@ namespace ifd {
 #else
 					std::string newPath = "/";
 #endif
-					for (int j = 0; j <= i; j++) {
+					for (size_t j = 0; j <= i; j++) {
 						newPath += btnList[j];
 #ifdef _WIN32
 						if (j != i)
@@ -544,7 +544,7 @@ namespace ifd {
 		// remove from sidebar
 		for (auto& p : m_treeCache)
 			if (p->Path == "Quick Access") {
-				for (int i = 0; i < p->Children.size(); i++)
+				for (size_t i = 0; i < p->Children.size(); i++)
 					if (p->Children[i]->Path == path) {
 						p->Children.erase(p->Children.begin() + i);
 						break;
@@ -660,9 +660,9 @@ namespace ifd {
 
 		std::vector<std::string> exts;
 
-		int lastSplit = 0, lastExt = 0;
+		size_t lastSplit = 0, lastExt = 0;
 		bool inExtList = false;
-		for (int i = 0; i < filter.size(); i++) {
+		for (size_t i = 0; i < filter.size(); i++) {
 			if (filter[i] == ',') {
 				if (!inExtList)
 					lastSplit = i + 1;
@@ -876,7 +876,7 @@ namespace ifd {
 	}
 	void FileDialog::m_loadPreview()
 	{
-		for (int i = 0; m_previewLoaderRunning && i < m_content.size(); i++) {
+		for (size_t i = 0; m_previewLoaderRunning && i < m_content.size(); i++) {
 			auto& data = m_content[i];
 
 			if (data.HasIconPreview)
@@ -1010,7 +1010,7 @@ namespace ifd {
 
 		if (m_content.size() > 0) {
 			// find where the file list starts
-			int fileIndex = 0;
+			size_t fileIndex = 0;
 			for (; fileIndex < m_content.size(); fileIndex++)
 				if (!m_content[fileIndex].IsDirectory)
 					break;
@@ -1218,7 +1218,7 @@ namespace ifd {
 		if (openNewDirectoryDlg)
 			ImGui::OpenPopup("Enter directory name##newdir");
 		if (ImGui::BeginPopupModal("Are you sure?##delete")) {
-			if (m_selectedFileItem >= m_content.size() || m_content.size() == 0)
+			if (m_selectedFileItem >= static_cast<int>(m_content.size()) || m_content.size() == 0)
 				ImGui::CloseCurrentPopup();
 			else {
 				const FileData& data = m_content[m_selectedFileItem];
@@ -1369,13 +1369,18 @@ namespace ifd {
 #ifdef _WIN32
 			if (!success)
 				MessageBeep(MB_ICONERROR);
+#else
+			(void)success;
 #endif
 		}
 		if (m_type != IFD_DIALOG_DIRECTORY) {
 			ImGui::SameLine();
 			ImGui::SetNextItemWidth(-FLT_MIN);
-			if (ImGui::Combo("##ext_combo", &m_filterSelection, m_filter.c_str()))
+			int sel = static_cast<int>(m_filterSelection);
+			if (ImGui::Combo("##ext_combo", &sel, m_filter.c_str())) {
+				m_filterSelection = static_cast<size_t>(sel);
 				m_setDirectory(m_currentDirectory, false); // refresh
+			}
 		}
 
 		// buttons
@@ -1388,6 +1393,8 @@ namespace ifd {
 #ifdef _WIN32
 			if (!success)
 				MessageBeep(MB_ICONERROR);
+#else
+			(void)success;
 #endif
 		}
 		ImGui::SameLine();

--- a/ImFileDialog.h
+++ b/ImFileDialog.h
@@ -138,7 +138,4 @@ namespace ifd {
 		void m_renderPopups();
 		void m_renderFileDialog();
 	};
-
-	static const char* GetDefaultFolderIcon();
-	static const char* GetDefaultFileIcon();
 }

--- a/ImFileDialog.h
+++ b/ImFileDialog.h
@@ -108,7 +108,7 @@ namespace ifd {
 
 		std::string m_filter;
 		std::vector<std::vector<std::string>> m_filterExtensions;
-		int m_filterSelection;
+		size_t m_filterSelection;
 		void m_parseFilter(const std::string& filter);
 
 		std::vector<int> m_iconIndices;

--- a/example.cpp
+++ b/example.cpp
@@ -1,7 +1,7 @@
 #include <SDL2/SDL.h>
-#include <imgui/imgui.h>
-#include <imgui/examples/imgui_impl_sdl.h>
-#include <imgui/examples/imgui_impl_opengl3.h>
+#include <imgui.h>
+#include <backends/imgui_impl_sdl.h>
+#include <backends/imgui_impl_opengl3.h>
 #include <time.h>
 
 #ifdef _WIN32


### PR DESCRIPTION
Builds on #17.

This improves the behavior of the Cancel function. Previously, when pressing the Cancel button in the bottom bar, a path was returned via `HasResult()` if the dialog type was `IFD_DIALOG_DIRECTORY`, the same as when `Open` was pressed.

Also the ESCAPE key can now be pressed to cancel the dialog.