### PR TITLE
fixed use after free

### DIFF
--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -939,16 +939,16 @@ namespace ifd {
 			m_clearIcons();
 		}
 
-		if (p.u8string() == "Quick Access") {
+		if (m_currentDirectory.u8string() == "Quick Access") {
 			for (auto& node : m_treeCache) {
-				if (node->Path == p)
+				if (node->Path == m_currentDirectory)
 					for (auto& c : node->Children)
 						m_content.push_back(FileData(c->Path));
 			}
 		} 
-		else if (p.u8string() == "This PC") {
+		else if (m_currentDirectory.u8string() == "This PC") {
 			for (auto& node : m_treeCache) {
-				if (node->Path == p)
+				if (node->Path == m_currentDirectory)
 					for (auto& c : node->Children)
 						m_content.push_back(FileData(c->Path));
 			}


### PR DESCRIPTION
ran my app with valgrind and it found a use after free with line 930 to blame which drops p before it is then used in lines 942, 944, 949 and 951:

930:

```
m_content.clear(); // p == "" after this line, due to reference
```