### PR TITLE
Fix for ImGui v1.92

### DIFF
--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -24,7 +24,7 @@
 #include <pwd.h>
 #endif
 
-#define ICON_SIZE ImGui::GetFont()->FontSize + 3
+#define ICON_SIZE ImGui::GetFontSize() + 3
 #define GUI_ELEMENT_SIZE std::max(GImGui->FontSize + 10.f, 24.f)
 #define DEFAULT_ICON_SIZE 32
 #define PI 3.141592f


### PR DESCRIPTION
Hi,

This PR adds two fixes:

1. the icon size shall vary depending on FontGlobalScale (this enables a better rendering on high DPI platforms)
2. Fix for an incoming API change in v1.92, cf https://github.com/ocornut/imgui/issues/8465

thanks! 