### PR TITLE
Fix for ImGui 1.92.8 PathStroke arg swap

### DIFF
--- a/ImFileDialog.cpp
+++ b/ImFileDialog.cpp
@@ -274,7 +274,11 @@ namespace ifd {
 			float radius = i & 1 ? innerRadius : outerRadius;
 			window->DrawList->PathLineTo(ImVec2(center.x + radius * sin(i * angle), center.y - radius * cos(i * angle)));
 		}
+#if IMGUI_VERSION_NUM < 19276
 		window->DrawList->PathStroke(ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]), true, 2.0f);
+#else
+		window->DrawList->PathStroke(ImGui::ColorConvertFloat4ToU32(ImGui::GetStyle().Colors[ImGuiCol_Text]), 2.0f, ImDrawFlags_Closed);
+#endif
 
 		return ret;
 	}


### PR DESCRIPTION
Gate the PathStroke call on IMGUI_VERSION_NUM < 19276 : last two args (flags, thickness) were swapped to (thickness, flags) in ocornut/imgui v1.92.8.